### PR TITLE
Add Django FMS 2.8.1 for finite state machine in models

### DIFF
--- a/fileUpload/base.py
+++ b/fileUpload/base.py
@@ -17,6 +17,7 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     'rest_framework',
     'django_filters',
+    'django_fsm',
     'user',
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,4 +14,4 @@ black==23.1.0
 djangorestframework==3.14.0
 markdown==3.4.3
 django-filter==22.1
-
+django-fsm==2.8.1


### PR DESCRIPTION
Add  Django FMS  requirements.txt and app list in base.py settings to enable the 
use of finite state machines in Django models. With Django FMS, we can create 
stateful models that can transition between different states based on predefined rules.