### PR TITLE
feat: Add FileUploadViewSet and CSV file upload functionality

### DIFF
--- a/uploads/file.csv
+++ b/uploads/file.csv
@@ -1,0 +1,1 @@
+csv_file_content

--- a/uploads/file_LPT5HLM.csv
+++ b/uploads/file_LPT5HLM.csv
@@ -1,0 +1,1 @@
+csv_file_content

--- a/uploads/file_bc8TMKK.csv
+++ b/uploads/file_bc8TMKK.csv
@@ -1,0 +1,1 @@
+csv_file_content

--- a/user/tests/test_views.py
+++ b/user/tests/test_views.py
@@ -1,8 +1,15 @@
-from django.urls import reverse
+import io
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase
 from rest_framework import status
+from rest_framework.test import APIClient
+from django.urls import reverse
 from rest_framework.test import APITestCase
 
 from user.models import UserData
+from user.models import FileUpload
+
+from user.serializers import FileUploadSerializer
 
 
 class UserDataViewSetTests(APITestCase):
@@ -57,3 +64,41 @@ class UserDataViewSetTests(APITestCase):
         response = self.client.get(url, query_params)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["results"][0]["first_name"], "John")
+
+
+class FileUploadViewSetTestCase(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+
+    def test_upload_file(self):
+        file_data = io.BytesIO(b"csv_file_content")
+        file = SimpleUploadedFile(
+            "file.csv", file_data.getvalue(),
+            content_type="text/csv"
+        )
+        response = self.client.post(
+            "/v1/file-upload/", {"file": file}, format="multipart"
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(FileUpload.objects.count(), 1)
+        self.assertEqual(
+            response.data, FileUploadSerializer(
+                FileUpload.objects.first()).data
+            )
+
+    def test_upload_invalid_file_type(self):
+        file_data = io.BytesIO(
+            b"invalid_file_content"
+        )  # replace with your file content
+        file = SimpleUploadedFile(
+            "file.txt", file_data.getvalue(), content_type="text/plain"
+        )
+        response = self.client.post(
+            "/v1/file-upload/", {"file": file}, format="multipart"
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.data,
+            {"error": "Invalid file type. Only CSV files are allowed."}
+        )
+        self.assertEqual(FileUpload.objects.count(), 0)

--- a/user/urls.py
+++ b/user/urls.py
@@ -1,9 +1,10 @@
 from django.urls import path, include
 from rest_framework.routers import DefaultRouter
-from .views import UserDataViewSet
+from .views import UserDataViewSet, FileUploadViewSet
 
 router = DefaultRouter()
 router.register("users", UserDataViewSet, basename="user")
+router.register("file-upload", FileUploadViewSet, basename="file-upload")
 
 urlpatterns = [
     path("", include(router.urls)),

--- a/user/views.py
+++ b/user/views.py
@@ -1,10 +1,15 @@
-from rest_framework import pagination
+from rest_framework.parsers import FormParser, MultiPartParser
+from django.db import transaction
+from rest_framework.response import Response
+from rest_framework import status
 from rest_framework import filters
-from rest_framework.viewsets import GenericViewSet
+from rest_framework import pagination
+from rest_framework.viewsets import GenericViewSet, ModelViewSet
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework.mixins import ListModelMixin
-from .models import UserData
-from .serializers import UserDataSerializer
+from .models import UserData, FileUpload
+from .serializers import UserDataSerializer, FileUploadSerializer
+from .utils import FileExtensionValidator
 
 
 class UserPagination(pagination.PageNumberPagination):
@@ -43,3 +48,29 @@ class UserDataViewSet(ListModelMixin, GenericViewSet):
                 birth_date__range=[start_date, end_date])
 
         return queryset
+
+
+class FileUploadViewSet(ModelViewSet):
+    parser_classes = [MultiPartParser, FormParser]
+    serializer_class = FileUploadSerializer
+    queryset = FileUpload.objects.all()
+
+    def create(self, request):
+        file_obj = request.FILES.get("file")
+        extension_validator = FileExtensionValidator()
+
+        # Validate file extension
+        if not extension_validator.is_csv(file_obj.name):
+            return Response(
+                {"error": "Invalid file type. Only CSV files are allowed."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        # Save file upload object
+        with transaction.atomic():
+            file_upload = FileUpload(
+                file=file_obj, status=FileUpload.FILE_STATUS_PENDING
+            )
+            file_upload.save()
+
+        return Response(FileUploadSerializer(file_upload).data)


### PR DESCRIPTION
Added the FileUploadViewSet class with create() method that handles CSV file uploads. The view accepts only CSV files, validates the file extension using FileExtensionValidator, and saves the file upload object in the database. The file upload object is returned as a response in the serialized form.

Also added functionality for validating file headers using FileHeaderValidator.

This commit adds support for CSV file uploads and validation for a more robust file upload system.