### PR TITLE
Add spectacular api docs generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,56 @@ To run tests, run the following command
   tox
 ```
 
+
+## API Reference
+
+#### Put csv file
+
+```http
+  PUT /v1/file-upload/
+```
+
+| Parameter | Type     | Description                |
+| :-------- | :------- | :------------------------- |
+| `id` | `numeric` |  |
+| `file` | `string` | **Required**.  csv file |
+| `status` | `string` |  |
+
+#### Get item
+
+```http
+  GET /v1/users/
+```
+{
+  "count": 123,
+  "next": "/accounts/?page=4",
+  "previous": "/?page=2",
+  "results": [
+    {
+      "first_name": "string",
+      "last_name": "string",
+      "national_id": "string",
+      "birth_date": "2023-03-25",
+      "address": "string",
+      "country": "string",
+      "phone_number": "string",
+      "email": "user@example.com",
+      "finger_print_signature": "string"
+    }
+  ]
+}
+
+full  documentation can be found here:
+
+```http
+swagger:  /v1/api/schema/swagger-ui/
+```
+```http
+redoc:    /v1/api/schema/redoc/
+```
+```http
+```
+```http
+```
+
+

--- a/fileUpload/base.py
+++ b/fileUpload/base.py
@@ -15,10 +15,12 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
-    'rest_framework',
-    'django_filters',
-    'django_fsm',
-    'user',
+    "rest_framework",
+    "django_filters",
+    "django_fsm",
+    "drf_spectacular",
+    "drf_spectacular_sidecar",
+    "user",
 ]
 
 MIDDLEWARE = [
@@ -74,25 +76,37 @@ STATIC_URL = "static/"
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 REST_FRAMEWORK = {
-    'DEFAULT_RENDERER_CLASSES': [
-        'rest_framework.renderers.JSONRenderer',
-      
-        'rest_framework.renderers.BrowsableAPIRenderer',
+    "DEFAULT_RENDERER_CLASSES": [
+        "rest_framework.renderers.JSONRenderer",
+        "rest_framework.renderers.BrowsableAPIRenderer",
     ],
-    'DEFAULT_PARSER_CLASSES':
-    [
-        'rest_framework.parsers.JSONParser',
-    ]
+    "DEFAULT_PARSER_CLASSES": [
+        "rest_framework.parsers.JSONParser",
+    ],
 }
 
 # Celery settings
 CELERY_BROKER_URL = "redis://localhost:6379"
 CELERY_RESULT_BACKEND = "redis://localhost:6379"
-CELERY_ACCEPT_CONTENT = ['application/json']
-CELERY_TASK_SERIALIZER = 'json'
-CELERY_RESULT_SERIALIZER = 'json'
+CELERY_ACCEPT_CONTENT = ["application/json"]
+CELERY_TASK_SERIALIZER = "json"
+CELERY_RESULT_SERIALIZER = "json"
 CELERYD_MAX_TASKS_PER_CHILD = 1000
 CELERY_TASK_RESULT_EXPIRES = 60 * 60 * 24
 
 # Django FSM settings
-FSM_STATE_FIELD = 'status'
+FSM_STATE_FIELD = "status"
+
+REST_FRAMEWORK = {
+    "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
+}
+
+SPECTACULAR_SETTINGS = {
+    "TITLE": "FilE INGESTION",
+    "DESCRIPTION": "Process Files",
+    "VERSION": "1.0.0",
+    "SERVE_INCLUDE_SCHEMA": False,
+    "SWAGGER_UI_DIST": "SIDECAR",  # shorthand to use the sidecar instead
+    "SWAGGER_UI_FAVICON_HREF": "SIDECAR",
+    "REDOC_DIST": "SIDECAR",
+}

--- a/fileUpload/urls.py
+++ b/fileUpload/urls.py
@@ -1,29 +1,25 @@
 from django.contrib import admin
-from django.urls import path, include,re_path
+from django.urls import path, include
 from django.conf import settings
 from django.conf.urls.static import static
-from rest_framework import permissions
-from drf_yasg.views import get_schema_view
-from drf_yasg import openapi
-
-
-schema_view = get_schema_view(
-   openapi.Info(
-      title="Snippets API",
-      default_version='v1',
-      description="Test description",
-      terms_of_service="https://www.google.com/policies/terms/",
-      contact=openapi.Contact(email="contact@snippets.local"),
-      license=openapi.License(name="BSD License"),
-   ),
-   public=True,
-   permission_classes=[permissions.AllowAny],
+from drf_spectacular.views import (
+    SpectacularAPIView,
+    SpectacularRedocView,
+    SpectacularSwaggerView,
 )
 
 urlpatterns = [
     path("admin/", admin.site.urls),
     path("v1/", include("user.urls")),
-    re_path('v1/swagger(?P<format>\.json|\.yaml)$', schema_view.without_ui(cache_timeout=0), name='schema-json'),
-    re_path('v1/swagger/$', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
-    re_path('v1/redoc/$', schema_view.with_ui('redoc', cache_timeout=0), name='schema-redoc'),
+    path("v1/api/schema/", SpectacularAPIView.as_view(), name="schema"),
+    path(
+        "v1/api/schema/swagger-ui/",
+        SpectacularSwaggerView.as_view(url_name="schema"),
+        name="swagger-ui",
+    ),
+    path(
+        "v1/api/schema/redoc/",
+        SpectacularRedocView.as_view(url_name="schema"),
+        name="redoc",
+    ),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,5 @@ requests
 urllib3==1.22
 celery==5.2.7
 redis==4.5.3
+drf-spectacular==0.26.1
+drf-spectacular-sidecar==2023.3.1


### PR DESCRIPTION
This commit adds Swagger documentation for our API, making it easier for 
developers to understand and consume our API. Additionally, the README 
file has been updated with a reference to the API documentation, making it simple for users to access it