### PR TITLE
Added redirect functionality for empty URL to v1 root

### DIFF
--- a/fileUpload/urls.py
+++ b/fileUpload/urls.py
@@ -2,6 +2,8 @@ from django.contrib import admin
 from django.urls import path, include
 from django.conf import settings
 from django.conf.urls.static import static
+from django.views.generic.base import RedirectView
+
 from drf_spectacular.views import (
     SpectacularAPIView,
     SpectacularRedocView,
@@ -22,4 +24,6 @@ urlpatterns = [
         SpectacularRedocView.as_view(url_name="schema"),
         name="redoc",
     ),
+     path('', RedirectView.as_view(url='v1/')),
+    
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/uploads/file_psQlU3u.csv
+++ b/uploads/file_psQlU3u.csv
@@ -1,0 +1,1 @@
+csv_file_content


### PR DESCRIPTION
This commit adds redirect functionality for the empty URL path to the v1 root of our API. 
When a user visits the website with an empty URL, they will now be automatically 
redirected to the v1 root, ensuring that they can quickly and easily access the API. 