### PR TITLE
Add custom exception handlers for Django REST Framework

### DIFF
--- a/fileUpload/base.py
+++ b/fileUpload/base.py
@@ -99,6 +99,7 @@ FSM_STATE_FIELD = "status"
 
 REST_FRAMEWORK = {
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
+    'EXCEPTION_HANDLER': 'user.handler.custom_exception_handler'
 }
 
 SPECTACULAR_SETTINGS = {

--- a/fileUpload/urls.py
+++ b/fileUpload/urls.py
@@ -24,6 +24,5 @@ urlpatterns = [
         SpectacularRedocView.as_view(url_name="schema"),
         name="redoc",
     ),
-     path('', RedirectView.as_view(url='v1/')),
-    
+    path('', RedirectView.as_view(url='v1/')),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/user/handler.py
+++ b/user/handler.py
@@ -1,0 +1,28 @@
+from rest_framework.views import exception_handler
+from rest_framework import status
+
+
+def custom_exception_handler(exc, context):
+    # Call the default exception handler first to get the response object
+    response = exception_handler(exc, context)
+
+    # Check if a response was generated
+    if response is not None:
+        # Check for 404 error
+        if response.status_code == status.HTTP_404_NOT_FOUND:
+            message = "The requested resource could not be found."
+        # Check for 500 error
+        elif response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR:
+            message = "An internal server error occurred. Please try again later." # noqa
+        # For all other errors
+        else:
+            message = "An error occurred while processing your request. Please try again later." # noqa
+
+        # Create the response data with custom error message
+        response.data = {
+            "error": True,
+            "status_code": response.status_code,
+            "message": message,
+        }
+
+    return response


### PR DESCRIPTION
This commit adds custom exception handlers to improve error handling in the 
Django REST Framework API. The new exception handlers provide more
 helpful error messages for 404 and 500 errors, and include additional
 information such as the status code and error message.The custom 
exception handlers are defined in a new module called handlers.py, and are 
registered in the Django REST Framework settings. This makes it easy to 
modify or extend the exception handlers as needed in the future.