### PR TITLE
Fix flake8 exclude and run black before flake8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ redis==4.5.3
 drf-spectacular==0.26.1
 drf-spectacular-sidecar==2023.3.1
 xlrd==2.0.1
+autopep8==2.0.2

--- a/tox.ini
+++ b/tox.ini
@@ -3,10 +3,11 @@ envlist = py{3.6,3.7,3.8,3.9,3.10}
 
 [testenv]
 deps =
-    -rrequirements.txt
+    -r requirements.txt
     coverage
     flake8
     black
+    autopep8
     Django
 
 commands =
@@ -16,8 +17,23 @@ commands =
     # generate coverage HTML report
     coverage html
 
-    # check code style with Flake8
-    flake8 .
-
     # check and format code with Black
     black --check --diff .
+
+    # automatically format code with autopep8
+    autopep8 --in-place --recursive .
+
+    # check code style with Flake8 (exclude specified directories)
+    flake8
+
+[flake8]
+exclude =
+    migrations,
+    __pycache__,
+    manage.py,
+    settings.py,
+    env,
+    .env,
+    .tox,
+    venv,
+    bin


### PR DESCRIPTION
This commit updates the tox.ini file to exclude specified directories when running flake8 and to run black before flake8. Additionally, autopep8 has been added to the requirements.txt file and a command has been added to automatically format code with autopep8. This should improve code formatting and style consistency.

Changes made:

Updated the tox.ini file to exclude specified directories when running flake8 and to run black before flake8 Added autopep8 to the requirements.txt file
Added a command to the tox.ini file to automatically format code with autopep8.