### PR TITLE
Remove file.task.fail on user tasks

### DIFF
--- a/user/tasks.py
+++ b/user/tasks.py
@@ -12,8 +12,6 @@ logger = logging.getLogger()
 def process_uploaded_file(id):
     file = FileUpload.objects.filter(id=id).first()
     if not file:
-        file.mark_failed()
-        file.save()
         return
 
     file.start_processing()


### PR DESCRIPTION
The file instance  for the object does not exist and cannot be marked failed 