### PR TITLE
Remove black in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,6 @@ deps =
     -r requirements.txt
     coverage
     flake8
-    black
     autopep8
     Django
 
@@ -16,9 +15,6 @@ commands =
 
     # generate coverage HTML report
     coverage html
-
-    # check and format code with Black
-    black --check --diff .
 
     # automatically format code with autopep8
     autopep8 --in-place --recursive .


### PR DESCRIPTION
This commit removes the Black package, which is causing conflicts with Flake8 in the project.
Flake8 throws linting errors on files which have been reformatted using black python library